### PR TITLE
Adicionando arquivos requirements do airflow e dbt

### DIFF
--- a/orchestrate/requirements.txt
+++ b/orchestrate/requirements.txt
@@ -1,0 +1,1 @@
+apache-airflow==2.10.4

--- a/transform/requirements.txt
+++ b/transform/requirements.txt
@@ -1,0 +1,3 @@
+dbt-core==1.9.1
+dbt-snowflake==1.9.0
+python-dotenv==1.0.1


### PR DESCRIPTION
Este PR tem o objetivo de disponibilizar os arquivos requirements.txt para o dbt project e apache airflow. Cada um deles deve ser instalado na respectiva venv.